### PR TITLE
update stackage resolver to 7.20 ( ghc 7.10 to 8.0.1 )

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-3.16
+resolver: lts-7.20
 packages:
 - '.'
 extra-deps:


### PR DESCRIPTION
Do we want to update to ghc 8?